### PR TITLE
Add `test.yaml` Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: test
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  project:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+        with:
+          submodules: true
+
+      - name: Run inference
+        shell: fish {0}
+        run: |
+          conda activate minimal-animatediff
+          python3 -m scripts.animate
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          path: samples/

--- a/modules/diffusion_model.py
+++ b/modules/diffusion_model.py
@@ -2,7 +2,9 @@ import os
 from safetensors import safe_open
 import urllib.request
 
-__model_file = 'models/toonyou_beta3.safetensors'
+from .utils import get_model_path
+
+__model_file = get_model_path('toonyou_beta3.safetensors')
 
 
 def load_model():

--- a/modules/motion_module.py
+++ b/modules/motion_module.py
@@ -2,7 +2,9 @@ import gdown
 import os
 import torch
 
-__state_dict_file = 'models/mm_sd_v15.ckpt'
+from .utils import get_model_path
+
+__state_dict_file = get_model_path('mm_sd_v15.ckpt')
 
 
 def load_state_dict():
@@ -14,4 +16,4 @@ def load_state_dict():
             exit('Failed to download motion module!')
 
     print('Loading motion module state dictionary...')
-    return torch.load('models/mm_sd_v15.ckpt', map_location='cpu')
+    return torch.load(__state_dict_file, map_location='cpu')

--- a/modules/stable_diffusion.py
+++ b/modules/stable_diffusion.py
@@ -4,6 +4,7 @@ from huggingface_hub import snapshot_download
 from transformers import CLIPTextModel, CLIPTokenizer
 
 from deps.AnimateDiff.animatediff.models.unet import UNet3DConditionModel
+from .utils import get_model_path
 
 __snapshot_dir = None
 
@@ -11,7 +12,7 @@ __snapshot_dir = None
 def check_snapshot():
     global __snapshot_dir
     print('Checking Stable Diffusion snapshot...')
-    __snapshot_dir = 'models/stable_diffusion'
+    __snapshot_dir = get_model_path('stable_diffusion')
     snapshot_download(repo_id='runwayml/stable-diffusion-v1-5', local_dir=__snapshot_dir)
 
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,0 +1,6 @@
+import os
+
+def get_model_path(model_name: str):
+    cache_path = os.environ.get('ANIMATEDIFF_MODELS_CACHE')
+    models_path = cache_path if cache_path is not None else 'models'
+    return os.path.join(models_path, model_name)


### PR DESCRIPTION
This pull request implements the following changes:

1. Introduces the `test.yaml` workflow, which facilitates the validation of the inference process. The workflow executes the necessary steps to test the correctness of the inference process and uploads the resulting output as an artifact.

2. Implements support for caching downloaded models in a specified directory. This enhancement allows users to set the cache location using the `ANIMATEDIFF_MODELS_CACHE` environment variable.

3. Adds a Dependabot configuration that monitors and checks for new versions of GitHub actions, ensuring that the project stays up to date with the latest improvements and fixes.

This pull request effectively closes #3.