### PR TITLE
Exclude Latest Branch from Pull Request Workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,9 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
+    branches: ['*', '!latest']
   push:
-    branches: [main]
+    branches: [latest, main]
 jobs:
   project:
     runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
Update the pull request events to trigger the `test.yaml` workflow only when the pull request targets branches other than the `latest` branch.