### PR TITLE
Integrate pytest-cov for Code Coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,5 +18,4 @@ jobs:
         shell: fish {0}
         run: |
           conda activate minimal-animatediff
-          python3 -m pytest --pylint -v -s --durations=0 \
-            --cov=minimal_animatediff --cov-fail-under=85
+          make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,4 +18,5 @@ jobs:
         shell: fish {0}
         run: |
           conda activate minimal-animatediff
-          python3 -m pytest --pylint -v -s --durations=0
+          python3 -m pytest --pylint -v -s --durations=0 \
+            --cov=minimal_animatediff --cov-fail-under=85

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.pylintrc
 
 __pycache__/
+coverage/
 flagged/
 models/
 samples/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 test:
-	python3 -m pytest --pylint -v -s --durations=0 \
-		--cov=minimal_animatediff --cov-fail-under=85
+	python3 -m pytest  -v -s \
+		--durations=0 \
+		--pylint \
+		--cov=minimal_animatediff \
+		--cov-fail-under=85 \
+		--cov-report term \
+		--cov-report annotate:coverage
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	python3 -m pytest --pylint -v -s --durations=0 \
+		--cov=minimal_animatediff --cov-fail-under=85
+
+.PHONY: test

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,6 +18,7 @@ dependencies:
     - imageio==2.27.0
     - pylint
     - pytest
+    - pytest-cov
     - pytest-dependency
     - pytest-pylint
     - safetensors

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -26,7 +26,7 @@ def test_run_animation_pipeline():
     SAMPLE = PIPELINE(
         'best quality, masterpiece, 1girl, cloudy sky, dandelion, alternate hairstyle,',
         negative_prompt     = '',
-        num_inference_steps = 25,
+        num_inference_steps = 10,
         guidance_scale      = 7.5,
         width               = 512,
         height              = 512,
@@ -42,4 +42,4 @@ def test_save_animation():
 
 @pytest.mark.dependency(depends=['test_save_animation'])
 def test_check_saved_animation_hash():
-    assert hasher.hash_file('samples/sample.gif') == '4d69e165159180fba534e4db9a395925'
+    assert hasher.hash_file('samples/sample.gif') == '30cc5fb2a6446f0849889b7a84ec1c42'


### PR DESCRIPTION
This pull request introduces [pytest-cov](https://pypi.org/project/pytest-cov/) to the testing process, enabling code coverage measurement when running tests. The code coverage results will be displayed in the terminal and also saved in the `coverage` directory, along with annotated source codes, for further analysis.

Additionally, this pull request includes the introduction of a [Makefile](https://www.gnu.org/software/make/manual/make.html), streamlining the process of running tests by simplifying commands and arguments.

The pull request effectively closes #20.