### PR TITLE
Video Output

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
     - flake8
     - gdown
     - huggingface_hub
-    - imageio==2.27.0
+    - imageio[ffmpeg]
     - pytest
     - pytest-cov
     - pytest-dependency

--- a/scripts/app.py
+++ b/scripts/app.py
@@ -27,10 +27,10 @@ if __name__ == "__main__":
         ).videos
 
         progress(steps / float(steps + 1), desc="Converting")
-        save_videos_grid(sample, "samples/sample.gif")
+        save_videos_grid(sample, "samples/sample.mp4")
 
         progress(1)
-        return "samples/sample.gif"
+        return "samples/sample.mp4"
 
     app = gradio.Interface(
         fn=generate,
@@ -42,7 +42,7 @@ if __name__ == "__main__":
             gradio.Number(label="Height", value=512, minimum=1),
             gradio.Number(label="Frames", value=16, minimum=1),
         ],
-        outputs=gradio.Image(label="Sample"),
+        outputs=gradio.Video(label="Generated Animation"),
     )
 
     app.launch(share=True, enable_queue=True)

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -35,11 +35,14 @@ def test_run_animation_pipeline():
 
 
 @pytest.mark.dependency(depends=["test_run_animation_pipeline"])
-def test_save_animation():
+def test_save_animation_gif():
     assert SAMPLE is not None
     save_videos_grid(SAMPLE, "samples/sample.gif")
-
-
-@pytest.mark.dependency(depends=["test_save_animation"])
-def test_check_saved_animation_hash():
     assert hasher.hash_file("samples/sample.gif") == "30cc5fb2a6446f0849889b7a84ec1c42"
+
+
+@pytest.mark.dependency(depends=["test_run_animation_pipeline"])
+def test_save_animation_mp4():
+    assert SAMPLE is not None
+    save_videos_grid(SAMPLE, "samples/sample.mp4")
+    assert hasher.hash_file("samples/sample.mp4") == "76494406baff329aa68d9c22ad0436cc"

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -1,12 +1,14 @@
 from filehash import FileHash
 import pytest
 import torch
+import os
 
 from deps.AnimateDiff.animatediff.utils.util import save_videos_grid
 from minimal_animatediff.animation_pipeline import create_animation_pipeline
 
 hasher = FileHash("md5")
 
+dir_path = os.path.dirname(os.path.realpath(__file__))
 PIPELINE = None
 SAMPLE = None
 
@@ -37,12 +39,14 @@ def test_run_animation_pipeline():
 @pytest.mark.dependency(depends=["test_run_animation_pipeline"])
 def test_save_animation_gif():
     assert SAMPLE is not None
-    save_videos_grid(SAMPLE, "samples/sample.gif")
-    assert hasher.hash_file("samples/sample.gif") == "30cc5fb2a6446f0849889b7a84ec1c42"
+    gif_path = os.path.join(dir_path, "samples/sample.gif")
+    save_videos_grid(SAMPLE, gif_path)
+    assert hasher.hash_file(gif_path) == "30cc5fb2a6446f0849889b7a84ec1c42"
 
 
 @pytest.mark.dependency(depends=["test_run_animation_pipeline"])
 def test_save_animation_mp4():
     assert SAMPLE is not None
-    save_videos_grid(SAMPLE, "samples/sample.mp4")
-    assert hasher.hash_file("samples/sample.mp4") == "76494406baff329aa68d9c22ad0436cc"
+    mp4_path = os.path.join(dir_path, "samples/sample.mp4")
+    save_videos_grid(SAMPLE, mp4_path)
+    assert hasher.hash_file(mp4_path) == "76494406baff329aa68d9c22ad0436cc"


### PR DESCRIPTION
This pull request introduces the following modifications:
- Outputs the pipeline result as a [Gradio Video](https://www.gradio.app/docs/video) in the Gradio App.
- Includes a test to save the generated video as an MP4 file and saves it relative to the test file. This test verifies the functionality of saving the video output in the desired format.