### PR TITLE
Add `MotionModuleModel` Class

### DIFF
--- a/minimal_animatediff/animation_pipeline.py
+++ b/minimal_animatediff/animation_pipeline.py
@@ -4,10 +4,10 @@ from diffusers import DDIMScheduler
 
 from deps.AnimateDiff.animatediff.pipelines.pipeline_animation import AnimationPipeline
 import deps.AnimateDiff.animatediff.utils.convert_from_ckpt as cvt
-import minimal_animatediff.motion_module as mm
 
 from . import utils
 from .dream_booth import DreamBoothModel
+from .motion_module import MotionModuleModel
 from .stable_diffusion import StableDiffusionSnapshot
 
 
@@ -35,7 +35,8 @@ def create_animation_pipeline():
     pipeline.to("cuda")
 
     print("Loading motion module to the animation pipeline...")
-    _, unexpected = pipeline.unet.load_state_dict(mm.load_state_dict(), strict=False)
+    mm_model = MotionModuleModel("mm_sd_v15.ckpt")
+    _, unexpected = pipeline.unet.load_state_dict(mm_model.states, strict=False)
     if len(unexpected) > 0:
         sys.exit("Failed to load motion module to the animation pipeline!")
 

--- a/minimal_animatediff/motion_module.py
+++ b/minimal_animatediff/motion_module.py
@@ -1,21 +1,9 @@
-import os
-import sys
-
-import gdown
 import torch
 
-from minimal_animatediff.utils import get_model_path
-
-__state_dict_file = get_model_path("mm_sd_v15.ckpt")
+from .utils import populate_snapshot
 
 
-def load_state_dict():
-    print("Checking motion module...")
-    if not os.path.isfile(__state_dict_file):
-        print("Motion module not found, downloading...")
-        gdown.download(id="1ql0g_Ys4UCz2RnokYlBjyOYPbttbIpbu", output=__state_dict_file, quiet=False)
-        if not os.path.isfile(__state_dict_file):
-            sys.exit("Failed to download motion module!")
-
-    print("Loading motion module state dictionary...")
-    return torch.load(__state_dict_file, map_location="cpu")
+class MotionModuleModel:
+    def __init__(self, name: str):
+        snapshot = populate_snapshot("motion_modules/" + name)
+        self.states = torch.load(snapshot, map_location="cpu")

--- a/tests/test_motion_module.py
+++ b/tests/test_motion_module.py
@@ -1,0 +1,19 @@
+from minimal_animatediff.motion_module import MotionModuleModel
+
+
+def test_init_motion_module_model():
+    model = MotionModuleModel("mm_sd_v15.ckpt")
+    assert len(model.states.keys()) == 560
+
+
+def test_init_other_motion_module_model():
+    model = MotionModuleModel("mm_sd_v14.ckpt")
+    assert len(model.states.keys()) == 560
+
+
+def test_init_non_existing_motion_module_model():
+    try:
+        MotionModuleModel("invalid.ckpt")
+        assert False
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
This pull request introduces the `MotionModuleModel` class, which serves the same purpose as the previously added `DreamBoothModel` class (#26), but specifically designed for handling the motion module.

Similar to the `DreamBoothModel` class, the `MotionModuleModel` class loads the motion module from the [threeal/AnimateDiffMirrors](https://huggingface.co/threeal/AnimateDiffMirrors) HuggingFace repository and then loads the state tensors available in that model.