### PR TITLE
Improved `StableDiffusion` and `MotionModule` Classes

### DIFF
--- a/minimal_animatediff/animation_pipeline.py
+++ b/minimal_animatediff/animation_pipeline.py
@@ -5,21 +5,19 @@ from diffusers import DDIMScheduler
 from deps.AnimateDiff.animatediff.pipelines.pipeline_animation import AnimationPipeline
 import deps.AnimateDiff.animatediff.utils.convert_from_ckpt as cvt
 
-from . import utils
 from .dream_booth import DreamBoothModel
 from .motion_module import MotionModuleModel
 from .stable_diffusion import StableDiffusionSnapshot
 
 
 def create_animation_pipeline():
-    sd_path = utils.get_model_path("stable_diffusion")
-    sd_snapshot = StableDiffusionSnapshot(sd_path)
+    sd_snapshot = StableDiffusionSnapshot()
 
     pipeline = AnimationPipeline(
-        text_encoder=sd_snapshot.load_text_encoder(),
-        tokenizer=sd_snapshot.load_tokenizer(),
-        vae=sd_snapshot.load_vae(),
-        unet=sd_snapshot.load_unet(),
+        text_encoder=sd_snapshot.text_encoder,
+        tokenizer=sd_snapshot.tokenizer,
+        vae=sd_snapshot.vae,
+        unet=sd_snapshot.unet,
         scheduler=DDIMScheduler(
             **{
                 "num_train_timesteps": 1000,

--- a/minimal_animatediff/animation_pipeline.py
+++ b/minimal_animatediff/animation_pipeline.py
@@ -6,7 +6,7 @@ from deps.AnimateDiff.animatediff.pipelines.pipeline_animation import AnimationP
 import deps.AnimateDiff.animatediff.utils.convert_from_ckpt as cvt
 
 from .dream_booth import DreamBoothModel
-from .motion_module import MotionModuleModel
+from .motion_module import MotionModule
 from .stable_diffusion import StableDiffusion
 
 
@@ -33,8 +33,8 @@ def create_animation_pipeline():
     pipeline.to("cuda")
 
     print("Loading motion module to the animation pipeline...")
-    mm_model = MotionModuleModel("mm_sd_v15.ckpt")
-    _, unexpected = pipeline.unet.load_state_dict(mm_model.states, strict=False)
+    mm = MotionModule("mm_sd_v15.ckpt")
+    _, unexpected = pipeline.unet.load_state_dict(mm.states, strict=False)
     if len(unexpected) > 0:
         sys.exit("Failed to load motion module to the animation pipeline!")
 

--- a/minimal_animatediff/animation_pipeline.py
+++ b/minimal_animatediff/animation_pipeline.py
@@ -7,17 +7,17 @@ import deps.AnimateDiff.animatediff.utils.convert_from_ckpt as cvt
 
 from .dream_booth import DreamBoothModel
 from .motion_module import MotionModuleModel
-from .stable_diffusion import StableDiffusionSnapshot
+from .stable_diffusion import StableDiffusion
 
 
 def create_animation_pipeline():
-    sd_snapshot = StableDiffusionSnapshot()
+    sd = StableDiffusion()
 
     pipeline = AnimationPipeline(
-        text_encoder=sd_snapshot.text_encoder,
-        tokenizer=sd_snapshot.tokenizer,
-        vae=sd_snapshot.vae,
-        unet=sd_snapshot.unet,
+        text_encoder=sd.text_encoder,
+        tokenizer=sd.tokenizer,
+        vae=sd.vae,
+        unet=sd.unet,
         scheduler=DDIMScheduler(
             **{
                 "num_train_timesteps": 1000,

--- a/minimal_animatediff/motion_module.py
+++ b/minimal_animatediff/motion_module.py
@@ -3,7 +3,7 @@ import torch
 from .utils import populate_snapshot
 
 
-class MotionModuleModel:
+class MotionModule:
     def __init__(self, name: str):
         snapshot = populate_snapshot("motion_modules/" + name)
         self.states = torch.load(snapshot, map_location="cpu")

--- a/minimal_animatediff/stable_diffusion.py
+++ b/minimal_animatediff/stable_diffusion.py
@@ -1,5 +1,3 @@
-import warnings
-
 from diffusers import AutoencoderKL
 from diffusers.utils.import_utils import is_xformers_available
 from huggingface_hub import snapshot_download
@@ -51,7 +49,5 @@ class StableDiffusionSnapshot:
             },
         )
 
-        if is_xformers_available():
-            self.unet.enable_xformers_memory_efficient_attention()
-        else:
-            warnings.warn("XFormers is not installed. memory-efficient is disabled", RuntimeWarning)
+        assert is_xformers_available()
+        self.unet.enable_xformers_memory_efficient_attention()

--- a/minimal_animatediff/stable_diffusion.py
+++ b/minimal_animatediff/stable_diffusion.py
@@ -6,12 +6,12 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from deps.AnimateDiff.animatediff.models.unet import UNet3DConditionModel
 
 
-class StableDiffusionSnapshot:
+class StableDiffusion:
     def __init__(self):
-        path = "snapshots/stable_diffusion"
+        snapshot = "snapshots/stable_diffusion"
         snapshot_download(
             repo_id="runwayml/stable-diffusion-v1-5",
-            local_dir=path,
+            local_dir=snapshot,
             allow_patterns=[
                 "text_encoder/*.json",
                 "text_encoder/*model.bin",
@@ -23,12 +23,12 @@ class StableDiffusionSnapshot:
             ],
         )
 
-        self.text_encoder = CLIPTextModel.from_pretrained(path, subfolder="text_encoder")
-        self.tokenizer = CLIPTokenizer.from_pretrained(path, subfolder="tokenizer")
-        self.vae = AutoencoderKL.from_pretrained(path, subfolder="vae")
+        self.text_encoder = CLIPTextModel.from_pretrained(snapshot, subfolder="text_encoder")
+        self.tokenizer = CLIPTokenizer.from_pretrained(snapshot, subfolder="tokenizer")
+        self.vae = AutoencoderKL.from_pretrained(snapshot, subfolder="vae")
 
         self.unet = UNet3DConditionModel.from_pretrained_2d(
-            path,
+            snapshot,
             subfolder="unet",
             unet_additional_kwargs={
                 "unet_use_cross_frame_attention": False,

--- a/minimal_animatediff/utils.py
+++ b/minimal_animatediff/utils.py
@@ -3,12 +3,6 @@ import os
 from huggingface_hub import snapshot_download
 
 
-def get_model_path(model_name: str):
-    cache_path = os.environ.get("ANIMATEDIFF_MODELS_CACHE")
-    models_path = cache_path if cache_path is not None else "models"
-    return os.path.join(models_path, model_name)
-
-
 def populate_snapshot(path: str) -> str:
     """
     Populates the snapshot of a specified path from the 'threeal/AnimateDiffMirrors' repository.

--- a/tests/test_motion_module.py
+++ b/tests/test_motion_module.py
@@ -1,19 +1,19 @@
-from minimal_animatediff.motion_module import MotionModuleModel
+from minimal_animatediff.motion_module import MotionModule
 
 
-def test_init_motion_module_model():
-    model = MotionModuleModel("mm_sd_v15.ckpt")
+def test_init_motion_module():
+    model = MotionModule("mm_sd_v15.ckpt")
     assert len(model.states.keys()) == 560
 
 
-def test_init_other_motion_module_model():
-    model = MotionModuleModel("mm_sd_v14.ckpt")
+def test_init_other_motion_module():
+    model = MotionModule("mm_sd_v14.ckpt")
     assert len(model.states.keys()) == 560
 
 
-def test_init_non_existing_motion_module_model():
+def test_init_non_existing_motion_module():
     try:
-        MotionModuleModel("invalid.ckpt")
+        MotionModule("invalid.ckpt")
         assert False
     except FileNotFoundError:
         pass

--- a/tests/test_stable_diffusion.py
+++ b/tests/test_stable_diffusion.py
@@ -1,13 +1,13 @@
 from diffusers import AutoencoderKL
 from transformers import CLIPTextModel, CLIPTokenizer
-from minimal_animatediff.stable_diffusion import StableDiffusionSnapshot
+from minimal_animatediff.stable_diffusion import StableDiffusion
 
 from deps.AnimateDiff.animatediff.models.unet import UNet3DConditionModel
 
 
-def test_init_stable_diffusion_snapshot():
-    snapshot = StableDiffusionSnapshot()
-    assert isinstance(snapshot.text_encoder, CLIPTextModel)
-    assert isinstance(snapshot.tokenizer, CLIPTokenizer)
-    assert isinstance(snapshot.vae, AutoencoderKL)
-    assert isinstance(snapshot.unet, UNet3DConditionModel)
+def test_init_stable_diffusion():
+    sd = StableDiffusion()
+    assert isinstance(sd.text_encoder, CLIPTextModel)
+    assert isinstance(sd.tokenizer, CLIPTokenizer)
+    assert isinstance(sd.vae, AutoencoderKL)
+    assert isinstance(sd.unet, UNet3DConditionModel)

--- a/tests/test_stable_diffusion.py
+++ b/tests/test_stable_diffusion.py
@@ -1,0 +1,13 @@
+from diffusers import AutoencoderKL
+from transformers import CLIPTextModel, CLIPTokenizer
+from minimal_animatediff.stable_diffusion import StableDiffusionSnapshot
+
+from deps.AnimateDiff.animatediff.models.unet import UNet3DConditionModel
+
+
+def test_init_stable_diffusion_snapshot():
+    snapshot = StableDiffusionSnapshot()
+    assert isinstance(snapshot.text_encoder, CLIPTextModel)
+    assert isinstance(snapshot.tokenizer, CLIPTokenizer)
+    assert isinstance(snapshot.vae, AutoencoderKL)
+    assert isinstance(snapshot.unet, UNet3DConditionModel)


### PR DESCRIPTION
This pull request introduces several enhancements to the project:

- Renamed `StableDiffusionSnapshot` to `StableDiffusion` and `MotionModuleModel` to `MotionModule`.
- Modified the `StableDiffusion` class to load components (such as the text encoder, tokenizer, etc.) during initialization.
- Added an assertion to check if [xFormers](https://github.com/facebookresearch/xformers) is not available during `StableDiffusion` initialization.
- Removed the `get_model_path` utility function.